### PR TITLE
Fix preview card

### DIFF
--- a/css/preview.css
+++ b/css/preview.css
@@ -50,7 +50,7 @@
 }
 
 .tc-preview .tc-summary {
-    display: table;
+    display: block;
     width: 100%
 }
 


### PR DESCRIPTION
`display: table` allows the box to expand its boundaries when text
overflows.

Resolves: https://github.com/jmau111/jm-twitter-cards/issues/87

Before:

<img width="1124" alt="screen shot 2018-08-08 at 10 23 07" src="https://user-images.githubusercontent.com/2256130/43843323-42811886-9af5-11e8-862a-c692147df13e.png">

After:

<img width="1119" alt="screen shot 2018-08-08 at 10 23 19" src="https://user-images.githubusercontent.com/2256130/43843325-4294a64e-9af5-11e8-94fb-114832cd7bc4.png">
