### PR TITLE
fixing a PHP warning

### DIFF
--- a/classes/thumbs.php
+++ b/classes/thumbs.php
@@ -27,6 +27,9 @@ class Thumbs {
 		}
 
 		$opts = \jm_tc_get_options();
+		if ( ! isset( $opts['twitterCardImgSize'] ) {
+			return false;
+		}
 		switch ( $opts['twitterCardImgSize'] ) {
 			case 'small':
 				add_image_size(


### PR DESCRIPTION
In case $opts has no 'twitterCardImgSize' member.

This shows up when running WP CLI commands.