### PR TITLE
refactoring + security updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3069,14 +3069,6 @@
         "webpack-bundle-analyzer": "^4.4.2",
         "webpack-cli": "^4.9.1",
         "webpack-dev-server": "^4.4.0"
-      },
-      "dependencies": {
-        "prettier": {
-          "version": "npm:wp-prettier@2.8.5",
-          "resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.8.5.tgz",
-          "integrity": "sha512-gkphzYtVksWV6D7/V530bTehKkhrABUru/Gy4reOLOHJoKH4i9lcE1SxqU2VDxC3gCOx/Nk9alZmWk6xL/IBCw==",
-          "dev": true
-        }
       }
     },
     "@wordpress/stylelint-config": {
@@ -9824,6 +9816,12 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true
+    },
+    "prettier": {
+      "version": "npm:wp-prettier@2.8.5",
+      "resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.8.5.tgz",
+      "integrity": "sha512-gkphzYtVksWV6D7/V530bTehKkhrABUru/Gy4reOLOHJoKH4i9lcE1SxqU2VDxC3gCOx/Nk9alZmWk6xL/IBCw==",
       "dev": true
     },
     "prettier-linter-helpers": {


### PR DESCRIPTION
- drop support for custom meta keys desc title
- security updates
- refactoring (delete useless classes, easter eggs, and old code)
- try some typing

even after merge, 13 won't be pushed to wordpress.org for now.